### PR TITLE
Corrects CORS origins for websockets

### DIFF
--- a/chat_api/src/main/java/com/group3/chat_api/config/WebSocketConfig.java
+++ b/chat_api/src/main/java/com/group3/chat_api/config/WebSocketConfig.java
@@ -30,9 +30,9 @@ public class WebSocketConfig implements WebSocketConfigurer {
         } else {
             // Default allowed origins for local development
             allowedOrigins = new String[] {
-                    "http://localhost:19006",
-                    "http://localhost:19000",
-                    "https://app.yourdomain.com" // Railway frontend domain
+                    "ws://localhost:19006",
+                    "ws://localhost:19000",
+                    "ws://app.yourdomain.com" // Railway frontend domain
             };
             logger.info("Using default WebSocket allowed origins: {}", Arrays.toString(allowedOrigins));
         }


### PR DESCRIPTION
Changes to allowed origins:

* [`chat_api/src/main/java/com/group3/chat_api/config/WebSocketConfig.java`](diffhunk://#diff-68e718f4c04e65a0066006b96bd14c0b7c158a8ad12972e9f8d278f768072333L33-R35): Updated the allowed origins for WebSocket connections from `http` to `ws` to ensure proper WebSocket communication.

Websockets communicates over `ws` not `http` so this will fix the allowed origins.